### PR TITLE
None (build action = none) project item added.

### DIFF
--- a/src/FubuCsProjFile.Testing/FubuCsProjFile.Testing.csproj
+++ b/src/FubuCsProjFile.Testing/FubuCsProjFile.Testing.csproj
@@ -76,6 +76,7 @@
     <Compile Include="GlobalSectionTester.cs" />
     <Compile Include="IntegrationTester.cs" />
     <Compile Include="MSBuildProjectTester.cs" />
+    <Compile Include="NoneTester.cs" />
     <Compile Include="ProjectReferenceTester.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SolutionTester.cs" />

--- a/src/FubuCsProjFile.Testing/NoneTester.cs
+++ b/src/FubuCsProjFile.Testing/NoneTester.cs
@@ -1,0 +1,32 @@
+﻿using FubuTestingSupport;
+using NUnit.Framework;
+
+namespace FubuCsProjFile.Testing
+{
+    [TestFixture]
+    public class NoneTester
+    {
+        [Test]
+        public void can_add_a_file_with_build_action_none()
+        {
+            var project = CsProjFile.CreateAtSolutionDirectory("MyProj", "myproj");
+            var content = new None("packages.config");
+
+            project.Add(content);
+
+            project.Save();
+
+            var project2 = CsProjFile.LoadFrom(project.FileName);
+            project2.Find<None>("packages.config")
+                .CopyToOutputDirectory.ShouldEqual(ContentCopy.Never);
+        }
+
+        [Test]
+        public void can_read_existing_items_with_build_action_set_to_none()
+        {
+            var project = CsProjFile.LoadFrom("SlickGridHarness.csproj.fake");
+
+            project.Find<None>(@"Paging\Paged.spark").ShouldNotBeNull();
+        }
+    }
+}

--- a/src/FubuCsProjFile/Content.cs
+++ b/src/FubuCsProjFile/Content.cs
@@ -16,6 +16,11 @@ namespace FubuCsProjFile
             CopyToOutputDirectory = ContentCopy.Never;
         }
 
+        protected Content(string buildAction, string include) : base(buildAction, include)
+        {
+            CopyToOutputDirectory = ContentCopy.Never;
+        }
+
         public ContentCopy CopyToOutputDirectory { get; set; }
 
         internal override MSBuildItem Configure(MSBuildItemGroup @group)

--- a/src/FubuCsProjFile/FubuCsProjFile.csproj
+++ b/src/FubuCsProjFile/FubuCsProjFile.csproj
@@ -53,6 +53,7 @@
     <Compile Include="CsProjFile.cs" />
     <Compile Include="EmbeddedResource.cs" />
     <Compile Include="FrameworkNameDetector.cs" />
+    <Compile Include="None.cs" />
     <Compile Include="ProjectReference.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="GlobalSection.cs" />

--- a/src/FubuCsProjFile/None.cs
+++ b/src/FubuCsProjFile/None.cs
@@ -1,0 +1,14 @@
+﻿namespace FubuCsProjFile
+{
+    public class None : Content
+    {
+        public None() : base()
+        {
+            this.Name = "None";
+        }
+
+        public None(string include) : base("None", include)
+        {
+        }
+    }
+}

--- a/src/FubuCsProjFile/ProjectItem.cs
+++ b/src/FubuCsProjFile/ProjectItem.cs
@@ -7,7 +7,7 @@ namespace FubuCsProjFile
 
     public abstract class ProjectItem
     {
-        private readonly string _name;
+        private string _name;
         private string _include;
 
         protected ProjectItem(string name)
@@ -24,6 +24,7 @@ namespace FubuCsProjFile
         public string Name
         {
             get { return _name; }
+            protected set { _name = value; }
         }
 
         public string Include


### PR DESCRIPTION
## Summary

I've added a new type `None` which is similar to the `Content` type.
## Use Case

Useful for manipulating files that have build action set to none, for example `packages.config`.
