### PR TITLE
Add an existing project file to a new solution file resolves #79

### DIFF
--- a/src/FubuCsProjFile.Testing/SolutionTester.cs
+++ b/src/FubuCsProjFile.Testing/SolutionTester.cs
@@ -129,6 +129,17 @@ namespace FubuCsProjFile.Testing
         }
 
         [Test]
+        public void add_an_existing_project_to_a_new_solution()
+        {
+            var solution = Solution.CreateNew(@"solutions\sillydir", "newsolution");
+            File.Copy("FubuMVC.SlickGrid.Docs.csproj.fake", "FubuMVC.SlickGrid.Docs.csproj", true);
+
+            solution.AddProject(CsProjFile.LoadFrom("FubuMVC.SlickGrid.Docs.csproj"));
+
+            solution.FindProject("FubuMVC.SlickGrid.Docs").ShouldNotBeNull();
+        }
+
+        [Test]
         public void trying_to_add_a_project_from_template_that_already_exists_should_throw()
         {
             var solution = Solution.LoadFrom("FubuMVC.SlickGrid.sln");

--- a/src/FubuCsProjFile/Solution.cs
+++ b/src/FubuCsProjFile/Solution.cs
@@ -274,6 +274,23 @@ namespace FubuCsProjFile
         }
 
         /// <summary>
+        /// Adds an existing project
+        /// </summary>
+        /// <param name="project"></param>
+        public void AddProject(CsProjFile project)
+        {
+            var existing = FindProject(project.ProjectName);
+            if (existing != null)
+            {
+                return;
+            }
+            
+            var reference = new SolutionProject(project, this.ParentDirectory);
+            this._projects.Add(reference);
+
+        }
+
+        /// <summary>
         /// Adds a new project based on the supplied template file
         /// </summary>
         /// <param name="projectName"></param>


### PR DESCRIPTION
## Scenario

This small feature enables adding existing project files to solutions.
## Implementation

New overload for `Solution.AddProject`
## Issue

Resolves issue #79
