### PR TITLE
Assembly reference specific version matches visual studio behaviour

### DIFF
--- a/src/FubuCsProjFile.Testing/AssemblyReferenceTester.cs
+++ b/src/FubuCsProjFile.Testing/AssemblyReferenceTester.cs
@@ -1,0 +1,27 @@
+﻿using System.Xml;
+using FubuCore.Configuration;
+using FubuCsProjFile.MSBuild;
+using FubuTestingSupport;
+using NUnit.Framework;
+using StructureMap.Configuration;
+
+namespace FubuCsProjFile.Testing
+{
+    [TestFixture]
+    public class AssemblyReferenceTester
+    {
+        [Test]
+        public void specific_version_should_serialize_using_boolean_string_that_matches_visual_studio_behaviour()
+        {
+
+            var reference = new AssemblyReference("log4net");
+            var element = new XmlDocument().CreateElement("Reference");
+            reference.Configure(new MSBuildItemGroup(new MSBuildProject(), element));
+
+            reference.SpecificVersion = false;
+            reference.Save();
+
+            element.GetElementsByTagName("SpecificVersion")[0].InnerText.ShouldEqual("False"); // and not "false"
+        }
+    }
+}

--- a/src/FubuCsProjFile.Testing/FubuCsProjFile.Testing.csproj
+++ b/src/FubuCsProjFile.Testing/FubuCsProjFile.Testing.csproj
@@ -67,6 +67,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AssemblyReferenceTester.cs" />
     <Compile Include="BuildConfigurationTester.cs" />
     <Compile Include="ContentTester.cs" />
     <Compile Include="creating_a_new_solution_with_projects.cs" />

--- a/src/FubuCsProjFile/AssemblyReference.cs
+++ b/src/FubuCsProjFile/AssemblyReference.cs
@@ -87,7 +87,7 @@ namespace FubuCsProjFile
 
             if (SpecificVersion.HasValue)
             {
-                this.BuildItem.SetMetadata("SpecificVersion", SpecificVersion.Value.ToString().ToLower());
+                this.BuildItem.SetMetadata("SpecificVersion", SpecificVersion.Value.ToString());
             }
 
             if (Private.HasValue)

--- a/src/FubuCsProjFile/CsProjFile.cs
+++ b/src/FubuCsProjFile/CsProjFile.cs
@@ -225,7 +225,7 @@ namespace FubuCsProjFile
 
         public void Save()
         {
-            _project.Save(_fileName);
+            this.Save(_fileName);
         }
 
         public void Save(string file)

--- a/src/FubuCsProjFile/Properties/AssemblyInfo.cs
+++ b/src/FubuCsProjFile/Properties/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("FubuCsProjFile")]
 
+[assembly: InternalsVisibleTo("FubuCsProjFile.Testing")]


### PR DESCRIPTION
## Scenario

Updating existing project files to change assembly reference hint paths, and want as little merge conflicts as possible
## Problem

`SpecificVersion` boolean is serialized `ToLower()` which is not the Visual Studio behaviour

Fubu

``` xml
 <Reference Include="log4net">
      <SpecificVersion>false</SpecificVersion>
      <HintPath>Lib\log4netdll</HintPath>
    </Reference>
```

Visual Studio

``` xml
 <Reference Include="log4net">
      <SpecificVersion>False</SpecificVersion>
      <HintPath>Lib\log4netdll</HintPath>
    </Reference>
```

Note the difference in boolean casing.
## Fix

This pull request removes the `ToLower` in `AssemblyReference` adds a unit test for the desired behaviour `AssemblyReferenceTester`
