### PR TITLE
Assembly reference private matches visual studio behaviour

### DIFF
--- a/src/FubuCsProjFile.Testing/AssemblyReferenceTester.cs
+++ b/src/FubuCsProjFile.Testing/AssemblyReferenceTester.cs
@@ -20,6 +20,7 @@ namespace FubuCsProjFile.Testing
             fileSystem.Copy("FubuMVC.SlickGrid.Docs.csproj.fake", "FubuMVC.SlickGrid.Docs.csproj");
             fileSystem.Copy("SlickGridHarness.csproj.fake", "SlickGridHarness.csproj");
         }
+
         [Test]
         public void specific_version_should_serialize_using_boolean_string_that_matches_visual_studio_behaviour()
         {
@@ -54,5 +55,18 @@ namespace FubuCsProjFile.Testing
             var project = CsProjFile.LoadFrom("FubuMVC.SlickGrid.Docs.csproj");
             project.All<AssemblyReference>().Any(assembly => assembly.AssemblyName.Equals("Newtonsoft.Json.dll")).ShouldBeTrue();
         }
-    }
+
+        [Test]
+        public void private_should_serialize_using_boolean_string_that_matches_visual_studio_behaviour()
+        {
+            var reference = new AssemblyReference("log4net");
+            var element = new XmlDocument().CreateElement("Reference");
+            reference.Configure(new MSBuildItemGroup(new MSBuildProject(), element));
+
+            reference.Private = false;
+            reference.Save();
+
+            element.GetElementsByTagName("Private")[0].InnerText.ShouldEqual("False"); // and not "false"
+        }
+	}
 }

--- a/src/FubuCsProjFile/AssemblyReference.cs
+++ b/src/FubuCsProjFile/AssemblyReference.cs
@@ -107,7 +107,7 @@ namespace FubuCsProjFile
 
             if (Private.HasValue)
             {
-                this.BuildItem.SetMetadata("Private", Private.Value.ToString().ToLower());
+                this.BuildItem.SetMetadata("Private", Private.Value.ToString());
             }
         }
     }


### PR DESCRIPTION
Fix for #133 
AssemblyReferenceTester.cs seems to have changed a lot but I've just added a test to the end of the file. It was previously using LF endings so the change also updates the endings to be consistent with other files in the project.
I can update the PR to revert the LF change if required?
